### PR TITLE
Implement namespaces and simple binary support.

### DIFF
--- a/lib/socket.io-client-simple.rb
+++ b/lib/socket.io-client-simple.rb
@@ -7,6 +7,7 @@ require 'event_emitter'
 require 'socket.io-client-simple/version'
 require 'socket.io-client-simple/error'
 require 'socket.io-client-simple/client'
+require 'socket.io-client-simple/byte_buffer'
 
 module SocketIO
   module Client

--- a/lib/socket.io-client-simple/byte_buffer.rb
+++ b/lib/socket.io-client-simple/byte_buffer.rb
@@ -1,0 +1,19 @@
+module SocketIO
+  module Client
+    module Simple
+
+      def self.as_byte_buffer(data)
+        ByteBuffer.new(data)
+      end
+
+      class ByteBuffer
+        attr_accessor :buffer
+
+        def initialize(byte_array)
+          return unless byte_array.is_a?(Array)
+          @buffer = byte_array.unshift(4).pack('C*')
+        end
+      end
+    end
+  end
+end

--- a/lib/socket.io-client-simple/version.rb
+++ b/lib/socket.io-client-simple/version.rb
@@ -1,7 +1,7 @@
 module SocketIO
   module Client
     module Simple
-      VERSION = "1.2.1"
+      VERSION = "1.2.2"
     end
   end
 end


### PR DESCRIPTION
Implement namespaces https://socket.io/docs/rooms-and-namespaces/

```
client = SocketIO::Client::Simple.connect url, path: '/custom_namespace'
```

and simple binary support. If you want to send binary data, you should put this packet (byte array) to `SocketIO::Client::Simple::ByteBuffer` class via `SocketIO::Client::Simple.as_byte_buffer` method:

```
client.emit :binary, SocketIO::Client::Simple.as_byte_buffer(byte_array)
```

@shokai Could you please provide review?